### PR TITLE
Bugfix in axes3d not raising an exception

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2633,7 +2633,7 @@ class Axes3D(Axes):
         argi = 6
         if len(args) < argi:
             raise ValueError('Wrong number of arguments. Expected %d got %d' %
-                       (argi, len(args)))
+                             (argi, len(args)))
 
         # first 6 arguments are X, Y, Z, U, V, W
         input_args = args[:argi]

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2632,7 +2632,7 @@ class Axes3D(Axes):
         # handle args
         argi = 6
         if len(args) < argi:
-            ValueError('Wrong number of arguments. Expected %d got %d' %
+            raise ValueError('Wrong number of arguments. Expected %d got %d' %
                        (argi, len(args)))
 
         # first 6 arguments are X, Y, Z, U, V, W


### PR DESCRIPTION
## PR Summary

Instantiating an exception, but not raising it, has no effect. 
Found using [lgtm.com](https://lgtm.com/projects/g/matplotlib/matplotlib/alerts/?mode=tree&severity=error&rule=1505923886371).


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
